### PR TITLE
[ja] Web/CSS/:not() の例にあるコメントの誤りを修正

### DIFF
--- a/files/ja/web/css/_colon_not/index.md
+++ b/files/ja/web/css/_colon_not/index.md
@@ -98,7 +98,7 @@ body :not(p) {
   text-decoration: underline;
 }
 
-/* <div> または <span> 要素ではない要素 */
+/* <div> または '.fancy' ではない要素 */
 body :not(div):not(.fancy) {
   font-weight: bold;
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
https://developer.mozilla.org/ja/docs/Web/CSS/:not にて、例のコメントに誤りがあったため修正を行いました。
念の為原文とも照らし合わせ、本 PR での修正が正しいことを確認しました。

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
